### PR TITLE
ci: sync torvalds/linux into v9fs/linux from test

### DIFF
--- a/.github/workflows/sync-torvalds-linux.yml
+++ b/.github/workflows/sync-torvalds-linux.yml
@@ -1,0 +1,162 @@
+name: Sync torvalds/linux into v9fs/linux
+
+# Lives in v9fs/test only (see #15). Writes refs/tags on v9fs/linux — never
+# workflow files — so the kernel mirror stays rebase-clean vs torvalds/linux.
+
+on:
+  schedule:
+    # Tag releases are infrequent; six-hourly is enough to catch v* tags.
+    - cron: "23 */6 * * *"
+  workflow_dispatch:
+    inputs:
+      publish_new_tags:
+        description: "Run kernel Image publish for each newly synced v* tag"
+        type: boolean
+        default: true
+      publish_upstream_tip:
+        description: "Also publish kernel-main from v9fs/linux upstream tip"
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+concurrency:
+  group: sync-torvalds-linux
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    outputs:
+      new_tags: ${{ steps.mirror.outputs.new_tags }}
+      upstream_sha: ${{ steps.mirror.outputs.upstream_sha }}
+    steps:
+      - name: Require V9FS_LINUX_SYNC_TOKEN
+        env:
+          TOKEN: ${{ secrets.V9FS_LINUX_SYNC_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ -z "${TOKEN}" ]; then
+            echo "::error::Missing secret V9FS_LINUX_SYNC_TOKEN"
+            echo "Create a fine-grained PAT (or GitHub App token) with:"
+            echo "  - v9fs/linux: Contents Read and Write (push refs/tags)"
+            echo "  - v9fs/test: Actions Read and Write (workflow_run / gh workflow run)"
+            echo "Store it as repo or org secret V9FS_LINUX_SYNC_TOKEN."
+            exit 1
+          fi
+
+      - name: Mirror torvalds master + new v* tags into v9fs/linux
+        id: mirror
+        env:
+          TOKEN: ${{ secrets.V9FS_LINUX_SYNC_TOKEN }}
+        run: |
+          set -euo pipefail
+          git version
+
+          work="${RUNNER_TEMP}/linux-mirror"
+          mkdir -p "${work}"
+          git init --bare "${work}/linux.git"
+          cd "${work}/linux.git"
+
+          git remote add torvalds https://github.com/torvalds/linux.git
+          git remote add v9fs "https://x-access-token:${TOKEN}@github.com/v9fs/linux.git"
+
+          before_tags="$(mktemp)"
+          after_tags="$(mktemp)"
+          new_tags_file="$(mktemp)"
+
+          git ls-remote --tags v9fs 'v*' \
+            | awk '{print $2}' \
+            | sed -e 's#refs/tags/##' -e 's#\^{}$##' \
+            | sort -u > "${before_tags}" || true
+
+          # Fast-forward-only update of the clean upstream mirror branch.
+          git fetch --no-tags torvalds master:refs/remotes/torvalds/master
+          upstream_sha=$(git rev-parse refs/remotes/torvalds/master)
+          git push v9fs refs/remotes/torvalds/master:refs/heads/upstream
+
+          # Fetch v* tags from torvalds; push only those missing on v9fs/linux.
+          git fetch --no-tags torvalds 'refs/tags/v*:refs/tags/v*'
+          git show-ref --tags \
+            | awk '/refs\/tags\/v/ {print $2}' \
+            | sed -e 's#refs/tags/##' -e 's#\^{}$##' \
+            | sort -u > "${after_tags}"
+
+          comm -13 "${before_tags}" "${after_tags}" > "${new_tags_file}" || true
+
+          while IFS= read -r tag; do
+            [ -n "${tag}" ] || continue
+            echo "Pushing new tag ${tag}"
+            git push v9fs "refs/tags/${tag}:refs/tags/${tag}"
+          done < "${new_tags_file}"
+
+          # Space-separated list for the follow-on job (rare; usually 0–1 tags).
+          new_tags=$(tr '\n' ' ' < "${new_tags_file}" | sed 's/[[:space:]]*$//')
+
+          {
+            echo "new_tags=${new_tags}"
+            echo "upstream_sha=${upstream_sha}"
+          } >> "${GITHUB_OUTPUT}"
+
+          echo "torvalds master -> v9fs/linux upstream @ ${upstream_sha}"
+          echo "new tags: ${new_tags:-<none>}"
+
+  publish-new-tags:
+    needs: sync
+    if: needs.sync.outputs.new_tags != ''
+    runs-on: ubuntu-latest
+    steps:
+      - name: Ensure GitHub CLI
+        run: |
+          set -euo pipefail
+          command -v gh >/dev/null || {
+            sudo apt-get update
+            sudo apt-get install -y --no-install-recommends gh
+          }
+          gh --version
+
+      - name: Trigger Image publish for each new tag
+        env:
+          # GITHUB_TOKEN cannot chain into new workflow runs; use the sync PAT.
+          GH_TOKEN: ${{ secrets.V9FS_LINUX_SYNC_TOKEN }}
+          NEW_TAGS: ${{ needs.sync.outputs.new_tags }}
+          DO_PUBLISH: ${{ github.event_name == 'schedule' && 'true' || inputs.publish_new_tags }}
+        run: |
+          set -euo pipefail
+          if [ "${DO_PUBLISH}" != "true" ]; then
+            echo "publish_new_tags disabled; synced tags only."
+            exit 0
+          fi
+          for tag in ${NEW_TAGS}; do
+            echo "workflow_run publish: linux_ref=${tag} release_tag=kernel-${tag}"
+            gh workflow run "Publish Linux kernel (arm64 Image)" \
+              --repo "${{ github.repository }}" \
+              -f linux_repository=v9fs/linux \
+              -f linux_ref="${tag}" \
+              -f release_tag="kernel-${tag}"
+          done
+
+  publish-upstream-tip:
+    needs: sync
+    if: github.event_name == 'workflow_dispatch' && inputs.publish_upstream_tip
+    runs-on: ubuntu-latest
+    steps:
+      - name: Ensure GitHub CLI
+        run: |
+          set -euo pipefail
+          command -v gh >/dev/null || {
+            sudo apt-get update
+            sudo apt-get install -y --no-install-recommends gh
+          }
+
+      - name: Trigger Image publish for upstream as kernel-main
+        env:
+          GH_TOKEN: ${{ secrets.V9FS_LINUX_SYNC_TOKEN }}
+        run: |
+          set -euo pipefail
+          gh workflow run "Publish Linux kernel (arm64 Image)" \
+            --repo "${{ github.repository }}" \
+            -f linux_repository=v9fs/linux \
+            -f linux_ref=upstream \
+            -f release_tag=kernel-main

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Add `sync-torvalds-linux.yml`: cron/`workflow_dispatch` mirrors `torvalds/linux` `master` → `v9fs/linux` `upstream` and newly seen `v*` tags from `v9fs/test` only (no CI files in the kernel tree; see #15). New tags can trigger `linux-kernel-publish.yml` via `gh workflow run` using `V9FS_LINUX_SYNC_TOKEN`.
 - Clean-slate rework started; prior implementation preserved under `old/rework-take-1/` (tag `rework-take-1`).
 - Rebuild harness (take 2): minimal Docker+QEMU guest-direct smoke test that mounts a 9p export and validates basic filesystem operations.
 - Add GitHub Actions:

--- a/TODO.md
+++ b/TODO.md
@@ -4,7 +4,9 @@
 - Add benchmark stages (fsx, postmark, dbench) to guest-direct CI.
 - Add a diod regression suite stage (guest-direct) to exercise the kernel v9fs client.
 - Decide whether to adopt a u-root/u-root+cpu initramfs for richer tooling distribution.
-- Wire `v9fs/linux` to trigger `repository_dispatch` into `linux-kernel-publish.yml`.
+- Configure repo/org secret `V9FS_LINUX_SYNC_TOKEN` (Contents write on `v9fs/linux`, Actions on `v9fs/test`) so `sync-torvalds-linux.yml` can push refs and chain publish.
+- After Image publish, chain Harness CI + wiki summary table + `results.json`/diff artifacts (#15 follow-on).
+- Retarget “linux pushes trigger test” work (#6) to sync/orchestrate from this repo.
 
 ## TODO
 


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/sync-torvalds-linux.yml` so **all** torvalds sync/orchestration stays in `v9fs/test` (contract #15).
- Fast-forwards `v9fs/linux` `upstream` from `torvalds/linux` `master`; pushes only newly seen `v*` tags (no force of maintainer branches).
- Optionally chains existing **Publish Linux kernel** via `gh workflow run` (PAT required — `GITHUB_TOKEN` cannot start new workflow runs).

## Setup required before the cron is useful
- [ ] Create fine-grained PAT (or GitHub App) with Contents R/W on `v9fs/linux` and Actions on `v9fs/test`
- [ ] Store as repo/org secret `V9FS_LINUX_SYNC_TOKEN`

## Test plan
- [ ] Set `V9FS_LINUX_SYNC_TOKEN`
- [ ] Run workflow_dispatch with `publish_new_tags=false`, `publish_upstream_tip=false` and confirm `upstream` FF + tag detection logs
- [ ] Re-run with `publish_upstream_tip=true` and confirm Publish Linux kernel starts for `kernel-main`
- [ ] Confirm no `.github` (or other) files appear on `v9fs/linux` from this workflow

Closes nothing by itself; implements the sync half of #15. Follow-on: harness `workflow_run` + wiki summary table.

Made with [Cursor](https://cursor.com)