### PR TITLE
ci: fix sync — seed master before gh repo sync

### DIFF
--- a/.github/workflows/sync-torvalds-linux.yml
+++ b/.github/workflows/sync-torvalds-linux.yml
@@ -64,26 +64,27 @@ jobs:
         run: |
           set -euo pipefail
 
-          # --- Branch: objects via gh repo sync (matching branch name = master) ---
-          # torvalds default is master; gh repo sync updates destination's master.
-          echo "gh repo sync v9fs/linux <- torvalds/linux (master)"
-          gh repo sync v9fs/linux --source torvalds/linux --branch master
+          # --- Branch: GitHub fork sync (v9fs/linux is a fork of torvalds/linux) ---
+          # gh repo sync / merge-upstream requires the branch to already exist on the
+          # fork. torvalds uses master; we keep upstream as the canonical mirror name.
+          if ! gh api "repos/v9fs/linux/git/ref/heads/master" >/dev/null 2>&1; then
+            seed_sha=$(gh api "repos/v9fs/linux/git/ref/heads/upstream" --jq .object.sha)
+            echo "Creating missing refs/heads/master from upstream @ ${seed_sha}"
+            gh api --method POST "repos/v9fs/linux/git/refs" \
+              -f ref="refs/heads/master" \
+              -f sha="${seed_sha}"
+          fi
+
+          echo "gh repo sync v9fs/linux master <- torvalds/linux (parent)"
+          gh repo sync v9fs/linux --branch master
 
           upstream_sha=$(gh api repos/v9fs/linux/commits/master --jq .sha)
           echo "master @ ${upstream_sha}"
 
-          # Canonical mirror name for this org is upstream — FF to the synced tip.
-          if gh api "repos/v9fs/linux/git/ref/heads/upstream" >/dev/null 2>&1; then
-            echo "Fast-forward refs/heads/upstream -> ${upstream_sha}"
-            gh api --method PATCH "repos/v9fs/linux/git/refs/heads/upstream" \
-              -f sha="${upstream_sha}" \
-              -F force=false
-          else
-            echo "Create refs/heads/upstream -> ${upstream_sha}"
-            gh api --method POST "repos/v9fs/linux/git/refs" \
-              -f ref="refs/heads/upstream" \
-              -f sha="${upstream_sha}"
-          fi
+          echo "Fast-forward refs/heads/upstream -> ${upstream_sha}"
+          gh api --method PATCH "repos/v9fs/linux/git/refs/heads/upstream" \
+            -f sha="${upstream_sha}" \
+            -F force=false
 
           # --- Tags: only missing recent v* (no full history backfill) ---
           # First page of /tags is newest-first; enough for cron catch-up of new releases.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Fix sync workflow: ensure fork `master` exists before `gh repo sync`, then FF canonical `upstream` (merge-upstream 404'd without `master`).
 - Revise `sync-torvalds-linux.yml` to use `gh repo sync` for `master` objects, fast-forward canonical `upstream`, and sync only newly missing recent `v*` tags (no full torvalds tag mirror).
 - Add `sync-torvalds-linux.yml`: cron/`workflow_dispatch` mirrors `torvalds/linux` `master` → `v9fs/linux` `upstream` and newly seen `v*` tags from `v9fs/test` only (no CI files in the kernel tree; see #15). New tags can trigger `linux-kernel-publish.yml` via `gh workflow run` using `V9FS_LINUX_SYNC_TOKEN`.
 - Clean-slate rework started; prior implementation preserved under `old/rework-take-1/` (tag `rework-take-1`).


### PR DESCRIPTION
## Summary
Dry-run of #17 failed with \`HTTP 404: Branch not found\` on merge-upstream because \`v9fs/linux\` had no \`master\` branch.

- Ensure \`master\` exists (seed from \`upstream\` if missing)
- \`gh repo sync v9fs/linux --branch master\` from parent \`torvalds/linux\`
- Fast-forward canonical \`upstream\` to that SHA
- Keep recent \`v*\` tag sync

Verified locally: after seeding \`master\`, \`gh repo sync\` brought master to torvalds tip in seconds.

## Test plan
- [ ] Merge and workflow_dispatch with publish flags false
- [ ] Confirm success and \`upstream\` matches torvalds \`master\`

Related: #15 #17

Made with [Cursor](https://cursor.com)