### PR TITLE
ci: harness workflow_run + wiki tip dashboard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,16 +5,92 @@ on:
   workflow_dispatch:
     inputs:
       kernel_release:
-        description: 'Release tag that provides arm64 Image (default: kernel-main)'
+        description: "Release tag that provides arm64 Image (default: kernel-latest)"
         required: true
-        default: 'kernel-main'
+        default: "kernel-latest"
         type: string
+      linux_ref:
+        description: "Optional linux git ref label for reports (e.g. v7.2)"
+        required: false
+        default: ""
+        type: string
+  workflow_run:
+    workflows: ["Publish Linux kernel (arm64 Image)"]
+    types: [completed]
 
 permissions:
   contents: read
+  actions: read
+
+concurrency:
+  group: harness-${{ github.event.workflow_run.id || github.run_id }}
+  cancel-in-progress: false
 
 jobs:
+  resolve:
+    if: >-
+      github.event_name != 'workflow_run' ||
+      github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    outputs:
+      kernel_release: ${{ steps.out.outputs.kernel_release }}
+      linux_ref: ${{ steps.out.outputs.linux_ref }}
+      should_run: ${{ steps.out.outputs.should_run }}
+    steps:
+      - name: Resolve kernel release
+        id: out
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            kr="${{ inputs.kernel_release }}"
+            lr="${{ inputs.linux_ref }}"
+          elif [ "${{ github.event_name }}" = "workflow_run" ]; then
+            # Tip publishes refresh kernel-latest; use that floating Image.
+            kr="kernel-latest"
+            lr=""
+            # Best-effort: parse concrete tag from the publish run display title / jobs.
+            pub_id="${{ github.event.workflow_run.id }}"
+            title="$(gh run view "$pub_id" --repo "${{ github.repository }}" --json displayTitle --jq .displayTitle || true)"
+            echo "triggering publish: $title"
+          else
+            # push: exercise harness against current tip Image when present.
+            kr="kernel-latest"
+            lr=""
+          fi
+
+          should_run=true
+          if ! gh release view "$kr" --repo "${{ github.repository }}" >/dev/null 2>&1; then
+            echo "Release $kr not found yet"
+            if [ "${{ github.event_name }}" = "push" ]; then
+              should_run=false
+            else
+              echo "::error::Required release $kr is missing"
+              exit 1
+            fi
+          fi
+
+          # Derive linux_ref from release notes / tag name when possible.
+          if [ -z "${lr}" ] && [ "$kr" != "kernel-latest" ] && [[ "$kr" == kernel-v* ]]; then
+            lr="${kr#kernel-}"
+          fi
+          if [ -z "${lr}" ] && [ "$kr" = "kernel-latest" ]; then
+            notes="$(gh release view kernel-latest --repo "${{ github.repository }}" --json body --jq .body || true)"
+            # Notes look like: Floating latest Image (currently v7.2 / kernel-v7.2).
+            lr="$(printf '%s\n' "$notes" | sed -n 's/.*currently \([^ /]*\).*/\1/p' | head -1 || true)"
+          fi
+
+          {
+            echo "kernel_release=${kr}"
+            echo "linux_ref=${lr}"
+            echo "should_run=${should_run}"
+          } >> "$GITHUB_OUTPUT"
+          echo "kernel_release=${kr} linux_ref=${lr} should_run=${should_run}"
+
   tests:
+    needs: resolve
+    if: needs.resolve.outputs.should_run == 'true'
     runs-on: ubuntu-24.04-arm
     strategy:
       fail-fast: false
@@ -28,7 +104,7 @@ jobs:
           - qemu-9p2000.L
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      KERNEL_RELEASE: ${{ inputs.kernel_release || 'kernel-main' }}
+      KERNEL_RELEASE: ${{ needs.resolve.outputs.kernel_release }}
       V9FS_DOCKER_IMAGE: ghcr.io/v9fs/docker:latest
     steps:
       - name: Checkout harness
@@ -97,3 +173,59 @@ jobs:
           path: logs
           retention-days: 7
 
+  report:
+    needs: [resolve, tests]
+    if: always() && needs.resolve.outputs.should_run == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      actions: read
+    steps:
+      - name: Checkout harness
+        uses: actions/checkout@v4
+
+      - name: Ensure GitHub CLI
+        run: |
+          set -euo pipefail
+          command -v gh >/dev/null || {
+            sudo apt-get update
+            sudo apt-get install -y --no-install-recommends gh
+          }
+
+      - name: Build results.json, diff, wiki dashboard
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          WIKI_TOKEN: ${{ secrets.V9FS_LINUX_SYNC_TOKEN }}
+          KERNEL_RELEASE: ${{ needs.resolve.outputs.kernel_release }}
+          LINUX_REF: ${{ needs.resolve.outputs.linux_ref }}
+          OUTDIR: report-out
+        run: |
+          set -euo pipefail
+          mkdir -p report-out
+          ./scripts/v9fs-ci-report
+          ls -la report-out
+
+      - name: Upload report artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: tip-regression-report
+          path: report-out
+          retention-days: 30
+
+      - name: Attach results.json to kernel-latest (best-effort)
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.V9FS_LINUX_SYNC_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ ! -f report-out/results.json ]; then
+            echo "no results.json"
+            exit 0
+          fi
+          if [ -z "${GH_TOKEN}" ]; then
+            echo "V9FS_LINUX_SYNC_TOKEN unset; skip release attach"
+            exit 0
+          fi
+          gh release view kernel-latest >/dev/null 2>&1 || exit 0
+          gh release upload kernel-latest report-out/results.json report-out/diff-report.md --clobber || true

--- a/.github/workflows/sync-torvalds-linux.yml
+++ b/.github/workflows/sync-torvalds-linux.yml
@@ -59,6 +59,9 @@ jobs:
           }
           gh --version
 
+      - name: Checkout harness (tag helpers)
+        uses: actions/checkout@v4
+
       - name: Sync upstream branch + track new v6+ tags
         id: mirror
         env:
@@ -68,7 +71,6 @@ jobs:
           set -euo pipefail
 
           major_ge_6() {
-            # v6, v6.18, v6.18-rc1, v7.0, ...
             local maj
             maj=$(printf '%s' "$1" | sed -E 's/^v([0-9]+).*/\1/')
             [[ "${maj}" =~ ^[0-9]+$ ]] && [ "${maj}" -ge 6 ]
@@ -120,7 +122,7 @@ jobs:
             fi
           done < "${candidates}"
 
-          latest_tag=$(sort -V "${candidates}" | tail -n1 || true)
+          latest_tag=$(./scripts/v9fs-newest-v6-tag < "${candidates}" || true)
           echo "latest v6+ tag on torvalds (from recent window): ${latest_tag:-<none>}"
 
           work="${RUNNER_TEMP}/tag-sync"

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- Harness CI: default to `kernel-latest`, run on successful kernel publish (`workflow_run`), emit `results.json`/diff, update wiki `Regression-Dashboard`, and attach results to `kernel-latest`.
+- Add `scripts/v9fs-ci-report` and `scripts/v9fs-newest-v6-tag` (kernel-aware tip ordering: `v7.2` > `v7.2-rc7`).
 - Tag policy: track only new **v6+** tags; build/publish/test only the **single newest** v6+ tag; also refresh floating **`kernel-latest`** release alias alongside `kernel-<tag>`.
 - Fix sync workflow: ensure fork `master` exists before `gh repo sync`, then FF canonical `upstream` (merge-upstream 404'd without `master`).
 - Revise `sync-torvalds-linux.yml` to use `gh repo sync` for `master` objects, fast-forward canonical `upstream`, and sync only newly missing recent `v*` tags (no full torvalds tag mirror).

--- a/TODO.md
+++ b/TODO.md
@@ -4,8 +4,8 @@
 - Add benchmark stages (fsx, postmark, dbench) to guest-direct CI.
 - Add a diod regression suite stage (guest-direct) to exercise the kernel v9fs client.
 - Decide whether to adopt a u-root/u-root+cpu initramfs for richer tooling distribution.
-- Configure repo/org secret `V9FS_LINUX_SYNC_TOKEN` (Contents write on `v9fs/linux`, Actions on `v9fs/test`) so `sync-torvalds-linux.yml` can push refs and chain publish.
-- After Image publish, chain Harness CI + wiki summary table + `results.json`/diff artifacts (#15 follow-on).
+- Configure repo/org secret `V9FS_LINUX_SYNC_TOKEN` (Contents write on `v9fs/linux`, Actions + Contents on `v9fs/test` for publish chaining and wiki/`results.json` attach).
+- After Image publish, harness `workflow_run` builds tip report + wiki summary table (`Regression-Dashboard`).
 - Retarget “linux pushes trigger test” work (#6) to sync/orchestrate from this repo.
 
 ## TODO

--- a/scripts/v9fs-ci-report
+++ b/scripts/v9fs-ci-report
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+# Build results.json + diff-report.md and optionally update the wiki dashboard.
+# Env:
+#   GH_TOKEN (required)
+#   GITHUB_REPOSITORY (owner/name)
+#   GITHUB_RUN_ID
+#   KERNEL_RELEASE (e.g. kernel-latest or kernel-v7.2)
+#   LINUX_REF (optional)
+#   WIKI_TOKEN (optional; if set, push Regression-Dashboard.md to repo wiki)
+set -euo pipefail
+
+repo="${GITHUB_REPOSITORY:?}"
+run_id="${GITHUB_RUN_ID:?}"
+kernel_release="${KERNEL_RELEASE:?}"
+linux_ref="${LINUX_REF:-}"
+run_url="https://github.com/${repo}/actions/runs/${run_id}"
+generated_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+outdir="${OUTDIR:-.}"
+mkdir -p "${outdir}"
+
+jobs_json="$(mktemp)"
+gh run view "${run_id}" --repo "${repo}" --json jobs > "${jobs_json}"
+
+python3 - <<PY
+import json, os, re, pathlib, shutil, subprocess, tempfile
+
+data = json.load(open("${jobs_json}"))
+job_list = data.get("jobs", [])
+
+suites = {}
+pat = re.compile(r"^tests \((.+)\)$")
+for job in job_list:
+    m = pat.match(job.get("name") or "")
+    if not m:
+        continue
+    suite = m.group(1)
+    conclusion = job.get("conclusion") or job.get("status") or "unknown"
+    if conclusion == "success":
+        status = "pass"
+    elif conclusion == "skipped":
+        status = "skip"
+    elif conclusion in ("failure", "timed_out", "cancelled"):
+        status = "fail"
+    else:
+        status = str(conclusion)
+    suites[suite] = {"status": status, "xfail": False}
+
+payload = {
+    "kernel_release": "${kernel_release}",
+    "linux_ref": "${linux_ref}",
+    "kernel_latest": ("${kernel_release}" == "kernel-latest") or "${kernel_release}".startswith("kernel-v"),
+    "run_url": "${run_url}",
+    "run_id": int("${run_id}"),
+    "generated_at": "${generated_at}",
+    "suites": dict(sorted(suites.items())),
+}
+
+outdir = pathlib.Path("${outdir}")
+results_path = outdir / "results.json"
+results_path.write_text(json.dumps(payload, indent=2) + "\n")
+print(f"wrote {results_path} suites={list(payload['suites'])}")
+
+prev = None
+prev_label = "previous"
+try:
+    td = tempfile.mkdtemp()
+    r = subprocess.run(
+        ["gh", "release", "download", "kernel-latest", "-p", "results.json", "-D", td, "--clobber"],
+        capture_output=True, text=True,
+    )
+    prev_path = pathlib.Path(td) / "results.json"
+    if r.returncode == 0 and prev_path.exists():
+        prev = json.loads(prev_path.read_text())
+        # Ignore self if same run_id
+        if prev.get("run_id") == payload["run_id"]:
+            prev = None
+        else:
+            prev_label = prev.get("linux_ref") or prev.get("kernel_release") or "previous"
+    shutil.rmtree(td, ignore_errors=True)
+except Exception as e:
+    print(f"note: no previous results.json ({e})")
+
+lines = []
+lines.append(f"# v9fs tip regression")
+lines.append("")
+lines.append(f"- current: `{payload.get('linux_ref') or payload['kernel_release']}` ({payload['kernel_release']})")
+lines.append(f"- run: {payload['run_url']}")
+lines.append(f"- generated: {payload['generated_at']}")
+lines.append("")
+lines.append(f"| Suite | Status | vs {prev_label} |")
+lines.append("| --- | --- | --- |")
+
+prev_suites = (prev or {}).get("suites") or {}
+for suite, info in payload["suites"].items():
+    cur = info.get("status", "?")
+    old = (prev_suites.get(suite) or {}).get("status")
+    if old is None:
+        delta = "new"
+    elif old == cur:
+        delta = "—"
+    elif old == "pass" and cur == "fail":
+        delta = "**REGRESSED**"
+    elif old == "fail" and cur == "pass":
+        delta = "improved"
+    else:
+        delta = f"{old}→{cur}"
+    lines.append(f"| {suite} | {cur} | {delta} |")
+
+diff_path = outdir / "diff-report.md"
+diff_path.write_text("\n".join(lines) + "\n")
+print(f"wrote {diff_path}")
+
+wiki = os.environ.get("WIKI_TOKEN", "").strip()
+if wiki:
+    owner, name = "${repo}".split("/", 1)
+    wiki_url = f"https://x-access-token:{wiki}@github.com/{owner}/{name}.wiki.git"
+    wdir = tempfile.mkdtemp(prefix="v9fs-wiki-")
+    try:
+        clone = subprocess.run(["git", "clone", "--depth=1", wiki_url, wdir], capture_output=True, text=True)
+        if clone.returncode != 0:
+            print("wiki clone failed; initializing new wiki checkout")
+            print(clone.stderr)
+            shutil.rmtree(wdir, ignore_errors=True)
+            pathlib.Path(wdir).mkdir(parents=True, exist_ok=True)
+            subprocess.check_call(["git", "init"], cwd=wdir)
+            subprocess.check_call(["git", "remote", "add", "origin", wiki_url], cwd=wdir)
+        dash = pathlib.Path(wdir) / "Regression-Dashboard.md"
+        tip = payload.get("linux_ref") or payload["kernel_release"]
+        body = []
+        body.append("# v9fs regression dashboard")
+        body.append("")
+        body.append(
+            f"Last tip: `{tip}` — "
+            f"[`{payload['kernel_release']}`](https://github.com/${repo}/releases/tag/{payload['kernel_release']}) / "
+            f"[`kernel-latest`](https://github.com/${repo}/releases/tag/kernel-latest) — "
+            f"[run]({payload['run_url']})"
+        )
+        body.append("")
+        body.append(f"| Suite | Status | vs previous tip (`{prev_label}`) | Notes |")
+        body.append("| --- | --- | --- | --- |")
+        for suite, info in payload["suites"].items():
+            cur = info.get("status", "?")
+            old = (prev_suites.get(suite) or {}).get("status")
+            if old is None:
+                delta = "new"
+            elif old == cur:
+                delta = "—"
+            elif old == "pass" and cur == "fail":
+                delta = "regressed"
+            elif old == "fail" and cur == "pass":
+                delta = "improved"
+            else:
+                delta = f"{old}→{cur}"
+            note = "xfail baseline" if info.get("xfail") else ""
+            body.append(f"| {suite} | {cur} | {delta} | {note} |")
+        body.append("")
+        body.append(f"Updated: {payload['generated_at']}")
+        dash.write_text("\n".join(body) + "\n")
+        subprocess.check_call(["git", "config", "user.email", "v9fs-ci@users.noreply.github.com"], cwd=wdir)
+        subprocess.check_call(["git", "config", "user.name", "v9fs-ci"], cwd=wdir)
+        subprocess.check_call(["git", "add", "Regression-Dashboard.md"], cwd=wdir)
+        st = subprocess.run(["git", "status", "--porcelain"], cwd=wdir, capture_output=True, text=True)
+        if st.stdout.strip():
+            subprocess.check_call(["git", "commit", "-m", f"ci: tip regression {tip}"], cwd=wdir)
+            push = subprocess.run(["git", "push", "-u", "origin", "HEAD:master"], cwd=wdir, capture_output=True, text=True)
+            if push.returncode != 0:
+                push = subprocess.run(["git", "push", "-u", "origin", "HEAD:main"], cwd=wdir, capture_output=True, text=True)
+            if push.returncode != 0:
+                print("wiki push failed:")
+                print(push.stderr)
+            else:
+                print("wiki dashboard updated")
+        else:
+            print("wiki unchanged")
+    finally:
+        shutil.rmtree(wdir, ignore_errors=True)
+else:
+    print("WIKI_TOKEN unset; skipped wiki update")
+PY

--- a/scripts/v9fs-newest-v6-tag
+++ b/scripts/v9fs-newest-v6-tag
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Emit newest v6+ tag name from stdin (one tag per line) using kernel-aware ordering:
+# releases outrank same-version -rcN (v7.2 > v7.2-rc7).
+set -euo pipefail
+python3 - <<'PY'
+import re, sys
+tags = [ln.strip() for ln in sys.stdin if ln.strip()]
+
+def major_ge_6(n: str) -> bool:
+    m = re.match(r"^v(\d+)", n)
+    return bool(m and int(m.group(1)) >= 6)
+
+def key(n: str):
+    m = re.match(r"^v(\d+)(?:\.(\d+))?(?:\.(\d+))?(?:-rc(\d+))?$", n)
+    if not m:
+        return (0, 0, 0, -1, n)
+    maj = int(m.group(1))
+    mi = int(m.group(2) or 0)
+    pa = int(m.group(3) or 0)
+    rc = m.group(4)
+    # Final release sorts after all rcs for the same X.Y.Z
+    rc_n = int(rc) if rc is not None else 10**9
+    return (maj, mi, pa, rc_n, n)
+
+cands = [t for t in tags if major_ge_6(t)]
+if not cands:
+    sys.exit(0)
+print(sorted(cands, key=key)[-1])
+PY


### PR DESCRIPTION
## Summary
- Harness defaults to **\`kernel-latest\`** and triggers on successful **Publish Linux kernel** via \`workflow_run\`.
- New \`report\` job writes \`results.json\` + \`diff-report.md\`, updates wiki **Regression-Dashboard**, and attaches reports to \`kernel-latest\` when possible.
- Adds \`scripts/v9fs-ci-report\` and \`scripts/v9fs-newest-v6-tag\` (so \`v7.2\` ranks above \`v7.2-rc7\`).

## Seed
A one-shot publish of tip \`v7.2\` with \`also_latest=true\` was started to create \`kernel-latest\`: https://github.com/v9fs/test/actions/runs/32780927740

## Test plan
- [ ] Wait for tip Image publish to finish and confirm \`kernel-latest\` + \`kernel-v7.2\` releases exist
- [ ] Merge this PR; confirm a harness \`workflow_run\` (or manual dispatch with \`kernel-latest\`) produces report artifacts
- [ ] Confirm wiki page \`Regression-Dashboard\` appears (requires \`V9FS_LINUX_SYNC_TOKEN\` Contents on \`v9fs/test\` / wiki access)

Related: #15 #3 #19

Made with [Cursor](https://cursor.com)