### PR TITLE
ci: build-in NET_9P_FD (unix/tcp) on published Images

### DIFF
--- a/.github/workflows/linux-kernel-publish.yml
+++ b/.github/workflows/linux-kernel-publish.yml
@@ -66,10 +66,10 @@ jobs:
               cfg=/workspaces/linux/scripts/config; \
               if [ -x "$cfg" ]; then \
                 "$cfg" --file "$out/.config" \
-                  -e NET_9P -e NET_9P_VIRTIO -e 9P_FS \
+                  -e NET_9P -e NET_9P_FD -e NET_9P_VIRTIO -e 9P_FS \
                   -e 9P_FS_POSIX_ACL -e 9P_FS_SECURITY -e 9P_FS_XATTR \
                   -e FS_POSIX_ACL -e TMPFS_POSIX_ACL \
-                  -e VIRTIO_PCI -e PCI; \
+                  -e UNIX -e VIRTIO_PCI -e PCI; \
                 make -C /workspaces/linux O="$out" olddefconfig; \
               else \
                 echo \"WARNING: missing scripts/config; relying on defconfig\"; \

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,8 +1,12 @@
 ## Unreleased
 
+<<<<<<< HEAD
 - Fix `v9fs-ci-report` heredoc quoting so tip/wiki markdown renders correctly.
 
 
+=======
+- Build-in `NET_9P_FD` (and `UNIX`) on published Images so diod-regression `trans=unix` mounts work; arm64 defconfig left FD as `=m` while virtio was forced `=y`.
+>>>>>>> 46e2adf (ci: build-in NET_9P_FD for diod unix mounts)
 - Harness CI: default to `kernel-latest`, run on successful kernel publish (`workflow_run`), emit `results.json`/diff, update wiki `Regression-Dashboard`, and attach results to `kernel-latest`.
 - Add `scripts/v9fs-ci-report` and `scripts/v9fs-newest-v6-tag` (kernel-aware tip ordering: `v7.2` > `v7.2-rc7`).
 - Tag policy: track only new **v6+** tags; build/publish/test only the **single newest** v6+ tag; also refresh floating **`kernel-latest`** release alias alongside `kernel-<tag>`.

--- a/scripts/v9fs-9p-protocol-tests
+++ b/scripts/v9fs-9p-protocol-tests
@@ -17,7 +17,7 @@ if [ -r /proc/config.gz ]; then
   cfg_out="/home/v9fs-test/test/logs/9p-kconfig.txt"
   mkdir -p "$(dirname "$cfg_out")"
   (zcat /proc/config.gz 2>/dev/null || gzip -dc /proc/config.gz 2>/dev/null || cat /proc/config.gz) \
-    | /usr/bin/grep -E '^(CONFIG_(NET_9P|9P|P9|VIRTIO_9P|NET_9P_VIRTIO|NET_9P_DEBUG|NET_9P_RDMA|NET_9P_XEN)|# CONFIG_(NET_9P|NET_9P_VIRTIO|NET_9P_RDMA) is not set)' \
+    | /usr/bin/grep -E '^(CONFIG_(NET_9P|9P|P9|VIRTIO_9P|NET_9P_FD|NET_9P_VIRTIO|NET_9P_DEBUG|NET_9P_RDMA|NET_9P_XEN)|# CONFIG_(NET_9P|NET_9P_FD|NET_9P_VIRTIO|NET_9P_RDMA) is not set)' \
     | sort -u \
     | tee "$cfg_out" || true
 else


### PR DESCRIPTION
## Summary
Tip `diod-regression` on `kernel-latest` (`v7.2`) failed with `9p: Could not find request transport: unix`. Virtio suites passed.

Root cause: arm64 defconfig leaves `NET_9P_FD=m`; publish only forced `-e NET_9P_VIRTIO`. Image-only guests never load the FD module that registers `unix`/`tcp`/`fd`. Not a tip removal of unix, and not a diod server bug.

## Changes
- `-e NET_9P_FD` and `-e UNIX` in `linux-kernel-publish.yml`
- Mention `NET_9P_FD` in protocol-tests config grep

## Test plan
- [ ] Merge
- [ ] Re-dispatch `linux-kernel-publish` for `v7.2` with `also_latest=true` (or wait for sync)
- [ ] Re-run harness; confirm `diod-regression` mounts succeed (or only real XFAILs remain)

Related: #15 #20 #21

Made with [Cursor](https://cursor.com)