### PR TITLE
ci: diod XFAIL refresh + suite-log fallback; fix CHANGES conflict

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,12 +1,8 @@
 ## Unreleased
 
-<<<<<<< HEAD
-- Fix `v9fs-ci-report` heredoc quoting so tip/wiki markdown renders correctly.
-
-
-=======
+- Refresh diod XFAIL baseline for tip `v7.2` (access/umount residuals); tee `make check` so timeout still yields a parseable suite log for XFAIL eval.
 - Build-in `NET_9P_FD` (and `UNIX`) on published Images so diod-regression `trans=unix` mounts work; arm64 defconfig left FD as `=m` while virtio was forced `=y`.
->>>>>>> 46e2adf (ci: build-in NET_9P_FD for diod unix mounts)
+- Fix `v9fs-ci-report` heredoc quoting so tip/wiki markdown renders correctly.
 - Harness CI: default to `kernel-latest`, run on successful kernel publish (`workflow_run`), emit `results.json`/diff, update wiki `Regression-Dashboard`, and attach results to `kernel-latest`.
 - Add `scripts/v9fs-ci-report` and `scripts/v9fs-newest-v6-tag` (kernel-aware tip ordering: `v7.2` > `v7.2-rc7`).
 - Tag policy: track only new **v6+** tags; build/publish/test only the **single newest** v6+ tag; also refresh floating **`kernel-latest`** release alias alongside `kernel-<tag>`.

--- a/diod/xfail.txt
+++ b/diod/xfail.txt
@@ -10,12 +10,14 @@
 #   t0010-v9fs-runasuser.t :: root cannot read file
 #
 # Keep this list minimal and update it intentionally when behavior changes.
+# Baseline refreshed 2026-08-25 against tip v7.2 after NET_9P_FD was built-in
+# (unix mounts work; residual access/umount semantics remain).
 
-t0010-v9fs-runasuser.t :: list long directory
 t0010-v9fs-runasuser.t :: root cannot read file
 t0010-v9fs-runasuser.t :: root cannot stat file
 t0010-v9fs-runasuser.t :: root cannot create file
-t0010-v9fs-runasuser.t :: root cannot create file
+t0010-v9fs-runasuser.t :: unmount mnt2
+t0010-v9fs-runasuser.t :: unmount mnt
 t0010-v9fs-runasuser.t :: mount filesystem with uname=root,access=any fails
 
 t0011-v9fs-allsquash.t :: root can create a directory, mode 755
@@ -32,4 +34,3 @@ t0013-v9fs-acl.t :: getfacl confirms ACL is set
 t0013-v9fs-acl.t :: it is set on the server too
 t0013-v9fs-acl.t :: getfacl confirms ACL is unset
 t0013-v9fs-acl.t :: it is unset on the server too
-

--- a/scripts/v9fs-build-initrd
+++ b/scripts/v9fs-build-initrd
@@ -82,7 +82,12 @@ if mount -t 9p -o "trans=virtio,version=${bootver},cache=loose" hostshare /mnt/9
           # The sharness tests expect helper binaries from src/cmd check_PROGRAMS.
           make -C src/cmd test_diodrun test_flock test_flock_single test_atomic_create test_pathwalk
 
+          mkdir -p /home/v9fs-test/test/logs
+          make_out="/home/v9fs-test/test/logs/diod-make.out"
+
           # These are the kernel v9fs client oriented tests.
+          # Tee console output so we can still eval XFAIL if timeout/TERM
+          # causes automake to delete t/*.log before writing test-suite.log.
           set +e
           timeout 15m make -C t check TESTS="\
             t0010-v9fs-runasuser.t \
@@ -91,12 +96,17 @@ if mount -t 9p -o "trans=virtio,version=${bootver},cache=loose" hostshare /mnt/9
             t0013-v9fs-acl.t \
             t0020-dbench.t \
             t0021-postmark.t \
-          "
-          make_rc="$?"
+          " 2>&1 | tee "$make_out"
+          make_rc="${PIPESTATUS[0]}"
           set -e
 
-          # Preserve the automake/sharness combined log in the harness logs dir.
+          # Prefer automake combined log; synthesize from tee if missing.
           suite="$build/t/test-suite.log"
+          if [ ! -f "$suite" ]; then
+            suite="/home/v9fs-test/test/logs/diod-test-suite.synthetic.log"
+            # Strip ANSI so FAIL: tokens parse cleanly.
+            sed -E "s/\x1B\[[0-9;]*[A-Za-z]//g" "$make_out" > "$suite" || true
+          fi
           cp -f "$suite" /home/v9fs-test/test/logs/diod-test-suite.log 2>/dev/null || true
 
           # Evaluate failures against the harness XFAIL baseline so we can track them

--- a/scripts/v9fs-diod-regression-eval
+++ b/scripts/v9fs-diod-regression-eval
@@ -35,13 +35,14 @@ failures_norm="${out_dir}/failures.txt"
 xfail_norm="${out_dir}/xfail.txt"
 unexpected="${out_dir}/unexpected.txt"
 
-# Extract failures from automake/sharness output.
+# Extract failures from automake/sharness output (or tee fallback).
 # We rely on lines like:
 #   FAIL: t0010-foo.t 38 - description
+# ANSI color codes are stripped first.
 #
 # Output format:
 #   t0010-foo.t :: description
-awk '
+sed -E 's/\x1B\[[0-9;]*[A-Za-z]//g' "${suite_log}" | awk '
   $1 == "FAIL:" {
     test=$2
     # Find the " - " separator between step number and description.
@@ -58,7 +59,7 @@ awk '
     }
     if (desc != "") print test " :: " desc
   }
-' "${suite_log}" >"${failures_raw}" || true
+' >"${failures_raw}" || true
 
 # Normalize: drop blank lines and comments, trim whitespace, stable sort.
 normalize() {


### PR DESCRIPTION
## Summary
- Refresh `diod/xfail.txt` for tip `v7.2` residuals after unix mounts work (access/umount + expected-fail mount).
- Tee `make check` and synthesize a suite log if automake deletes logs on timeout (root cause of prior `missing suite log` / eval exit 2).
- Strip ANSI in XFAIL eval; repair conflict markers accidentally left in `CHANGES.md` on main.

## Test plan
- [x] Local XFAIL eval against residual FAIL lines → unexpected 0
- [ ] Merge; dispatch harness on `kernel-latest`
- [ ] Confirm `diod-regression` concludes success (XFAIL-only) or only new unexpected failures
- [ ] After wiki Home is seeded in UI, report job can push `Regression-Dashboard`

Related: #22 #21

Made with [Cursor](https://cursor.com)