### PR TITLE
ci: diod non-root user + per-test timeout

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Run diod sharness as non-root user `v9fs` (so ACCESS_SINGLE / `--runas` negatives work); per-test `timeout` via automake `LOG_COMPILER` instead of one outer suite timeout.
 - Refresh diod XFAIL baseline for tip `v7.2` (access/umount residuals); tee `make check` so timeout still yields a parseable suite log for XFAIL eval.
 - Build-in `NET_9P_FD` (and `UNIX`) on published Images so diod-regression `trans=unix` mounts work; arm64 defconfig left FD as `=m` while virtio was forced `=y`.
 - Fix `v9fs-ci-report` heredoc quoting so tip/wiki markdown renders correctly.

--- a/diod/xfail.txt
+++ b/diod/xfail.txt
@@ -10,15 +10,9 @@
 #   t0010-v9fs-runasuser.t :: root cannot read file
 #
 # Keep this list minimal and update it intentionally when behavior changes.
-# Baseline refreshed 2026-08-25 against tip v7.2 after NET_9P_FD was built-in
-# (unix mounts work; residual access/umount semantics remain).
-
-t0010-v9fs-runasuser.t :: root cannot read file
-t0010-v9fs-runasuser.t :: root cannot stat file
-t0010-v9fs-runasuser.t :: root cannot create file
-t0010-v9fs-runasuser.t :: unmount mnt2
-t0010-v9fs-runasuser.t :: unmount mnt
-t0010-v9fs-runasuser.t :: mount filesystem with uname=root,access=any fails
+#
+# Note: t0010 "root cannot …" / uname=root negatives are NOT XFAIL'd here;
+# the suite must run as non-root user `v9fs` so those assertions are meaningful.
 
 t0011-v9fs-allsquash.t :: root can create a directory, mode 755
 t0011-v9fs-allsquash.t :: nobody can create a directory, mode 755

--- a/scripts/v9fs-build-initrd
+++ b/scripts/v9fs-build-initrd
@@ -78,18 +78,25 @@ if mount -t 9p -o "trans=virtio,version=${bootver},cache=loose" hostshare /mnt/9
             build="$(ls -d /workspaces/tmp/diod-build-* 2>/dev/null | sort | tail -n 1 || true)"
           fi
           [ -n "$build" ] || { echo "diod-regression: missing diod build dir"; exit 2; }
+          id -u v9fs >/dev/null 2>&1 || { echo "diod-regression: missing v9fs user (prepare step)"; exit 2; }
+
           cd "$build"
           # The sharness tests expect helper binaries from src/cmd check_PROGRAMS.
           make -C src/cmd test_diodrun test_flock test_flock_single test_atomic_create test_pathwalk
 
           mkdir -p /home/v9fs-test/test/logs
+          # Guest writes as non-root; keep build/logs writable across 9p uid maps.
+          chmod -R a+rwX "$build" /home/v9fs-test/test/logs /workspaces/tmp || true
           make_out="/home/v9fs-test/test/logs/diod-make.out"
 
-          # These are the kernel v9fs client oriented tests.
-          # Tee console output so we can still eval XFAIL if timeout/TERM
-          # causes automake to delete t/*.log before writing test-suite.log.
+          # Run as non-root so --runas=$(id -u) / access=$(id -u) match diod intent.
+          # Per-test timeout (LOG_COMPILER) so a hung script FAILs that test instead of
+          # stalling the whole suite under a single outer timeout.
           set +e
-          timeout 15m make -C t check TESTS="\
+          sudo -u v9fs -H make -C t check \
+            LOG_COMPILER=timeout \
+            AM_LOG_FLAGS=300 \
+            TESTS="\
             t0010-v9fs-runasuser.t \
             t0011-v9fs-allsquash.t \
             t0012-v9fs-multiuser.t \

--- a/scripts/v9fs-diod-regression-eval
+++ b/scripts/v9fs-diod-regression-eval
@@ -38,15 +38,17 @@ unexpected="${out_dir}/unexpected.txt"
 # Extract failures from automake/sharness output (or tee fallback).
 # We rely on lines like:
 #   FAIL: t0010-foo.t 38 - description
+#   ERROR: t0010-foo.t 1 - timed out / crashed
 # ANSI color codes are stripped first.
 #
 # Output format:
 #   t0010-foo.t :: description
 sed -E 's/\x1B\[[0-9;]*[A-Za-z]//g' "${suite_log}" | awk '
-  $1 == "FAIL:" {
+  $1 == "FAIL:" || $1 == "ERROR:" {
     test=$2
     # Find the " - " separator between step number and description.
     # Input tokens look like: FAIL: <test> <num> - <desc...>
+    # Timeout/driver lines may be: ERROR: <test> - <desc...>
     desc=""
     for (i=3; i<=NF; i++) {
       if ($i == "-" && i < NF) {
@@ -57,6 +59,7 @@ sed -E 's/\x1B\[[0-9;]*[A-Za-z]//g' "${suite_log}" | awk '
         break
       }
     }
+    if (desc == "" && NF >= 2) desc = "automake error/timeout"
     if (desc != "") print test " :: " desc
   }
 ' >"${failures_raw}" || true

--- a/scripts/v9fs-prepare-diod-regression
+++ b/scripts/v9fs-prepare-diod-regression
@@ -17,9 +17,20 @@ apt-get install -y --no-install-recommends \
   lua5.1 liblua5.1-0-dev \
   libcap-dev libmunge-dev libwrap0-dev \
   tclsh rsync perl \
-  sudo \
+  sudo passwd \
   acl \
   dbench postmark
+
+# Dedicated non-root user for sharness. diod's t0010+ encode
+# "root cannot …" / uname=root negatives against --runas=$(id -u) and
+# access=$(id -u); those are meaningless if the suite itself runs as uid 0.
+if ! id -u v9fs >/dev/null 2>&1; then
+  useradd --create-home --shell /bin/bash --user-group v9fs
+fi
+echo 'v9fs ALL=(ALL) NOPASSWD:ALL' >/etc/sudoers.d/v9fs-nopasswd
+chmod 440 /etc/sudoers.d/v9fs-nopasswd
+# Validate passwordless sudo before the guest boots.
+sudo -u v9fs sudo -n true
 
 # Clone/update source.
 if [ ! -d "${src}/.git" ]; then

--- a/scripts/v9fs-run-tests
+++ b/scripts/v9fs-run-tests
@@ -59,7 +59,7 @@ if [ -z "${wait_secs}" ]; then
   case "${tests}" in
     smoke) wait_secs=180 ;;
     fsx|postmark|dbench) wait_secs=900 ;;
-    diod-regression) wait_secs=1800 ;;
+    diod-regression) wait_secs=2400 ;;
     qemu-9p2000.L|diod-9p2000.L) wait_secs=600 ;;
     *) wait_secs=300 ;;
   esac


### PR DESCRIPTION
## Summary
- Create passwordless-sudo user \`v9fs\` during diod prepare; run \`make check\` as that user so \`--runas=\$(id -u)\` / \`access=\$(id -u)\` match diod’s “root cannot …” intent.
- Per-test timeout via \`LOG_COMPILER=timeout AM_LOG_FLAGS=300\` (no outer 15m kill that left empty FAIL lists / false green).
- Drop obsolete t0010 XFAILs that were guest-as-root artifacts; keep t0011/t0013 for now.
- Bump QEMU wait to 40m; treat automake \`ERROR:\` like \`FAIL:\` in XFAIL eval.

## Test plan
- [ ] Merge; dispatch harness on \`kernel-latest\`
- [ ] Confirm t0010 root-negative steps PASS (or only real tip bugs remain)
- [ ] Confirm a hung test would surface as FAIL/ERROR for that script, not suite-wide empty PASS

Related: #23

Made with [Cursor](https://cursor.com)