### PR TITLE
ci: instrument diod t0010 mount + prepare harden

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Instrument diod `t0010` first `access=<uid>` mount (stderr/dmesg/diod log), pin `version=9p2000.L`, pre-create export, `Defaults !requiretty`, and force a fresh patched build stamp so CI can triage residual non-root mount failures.
 - Run diod sharness as non-root user `v9fs` (so ACCESS_SINGLE / `--runas` negatives work); per-test `timeout` via automake `LOG_COMPILER` instead of one outer suite timeout.
 - Refresh diod XFAIL baseline for tip `v7.2` (access/umount residuals); tee `make check` so timeout still yields a parseable suite log for XFAIL eval.
 - Build-in `NET_9P_FD` (and `UNIX`) on published Images so diod-regression `trans=unix` mounts work; arm64 defconfig left FD as `=m` while virtio was forced `=y`.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - Instrument diod `t0010` first `access=<uid>` mount (stderr/dmesg/diod log), pin `version=9p2000.L`, pre-create export, `Defaults !requiretty`, and force a fresh patched build stamp so CI can triage residual non-root mount failures.
+- Fix non-root `ACCESS_SINGLE` mounts: use `capsh` mount/umount as test uid (util-linux `sudo mount` post-check runs as root and fails with “Operation not permitted” even when attach succeeds).
 - Run diod sharness as non-root user `v9fs` (so ACCESS_SINGLE / `--runas` negatives work); per-test `timeout` via automake `LOG_COMPILER` instead of one outer suite timeout.
 - Refresh diod XFAIL baseline for tip `v7.2` (access/umount residuals); tee `make check` so timeout still yields a parseable suite log for XFAIL eval.
 - Build-in `NET_9P_FD` (and `UNIX`) on published Images so diod-regression `trans=unix` mounts work; arm64 defconfig left FD as `=m` while virtio was forced `=y`.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,7 @@
 ## Unreleased
 
 - Instrument diod `t0010` first `access=<uid>` mount (stderr/dmesg/diod log), pin `version=9p2000.L`, pre-create export, `Defaults !requiretty`, and force a fresh patched build stamp so CI can triage residual non-root mount failures.
-- Fix non-root `ACCESS_SINGLE` mounts: use `capsh` mount/umount as test uid (util-linux `sudo mount` post-check runs as root and fails with “Operation not permitted” even when attach succeeds).
+- Fix non-root `ACCESS_SINGLE` mounts: compile `scripts/v9fs-mount-9p` (direct `mount(2)`, no util-linux post-check) for sharness `v9fs_access_mount`.
 - Run diod sharness as non-root user `v9fs` (so ACCESS_SINGLE / `--runas` negatives work); per-test `timeout` via automake `LOG_COMPILER` instead of one outer suite timeout.
 - Refresh diod XFAIL baseline for tip `v7.2` (access/umount residuals); tee `make check` so timeout still yields a parseable suite log for XFAIL eval.
 - Build-in `NET_9P_FD` (and `UNIX`) on published Images so diod-regression `trans=unix` mounts work; arm64 defconfig left FD as `=m` while virtio was forced `=y`.

--- a/scripts/v9fs-build-initrd
+++ b/scripts/v9fs-build-initrd
@@ -116,6 +116,12 @@ if mount -t 9p -o "trans=virtio,version=${bootver},cache=loose" hostshare /mnt/9
           fi
           cp -f "$suite" /home/v9fs-test/test/logs/diod-test-suite.log 2>/dev/null || true
 
+          # Scoop t0010 mount instrumentation + diod server logs for CI artifacts.
+          cp -f /home/v9fs-test/test/logs/diod-t0010-mount-debug.txt \
+            /home/v9fs-test/test/logs/ 2>/dev/null || true
+          find "$build/t" -maxdepth 3 \( -name '*.diod.log' -o -name 'diod-t0010-mount-debug.txt' \) \
+            -exec cp -f {} /home/v9fs-test/test/logs/ \; 2>/dev/null || true
+
           # Evaluate failures against the harness XFAIL baseline so we can track them
           # without failing the overall CI stage unless a regression appears.
           eval_out="/home/v9fs-test/test/logs/diod-xfail"

--- a/scripts/v9fs-build-initrd
+++ b/scripts/v9fs-build-initrd
@@ -93,7 +93,7 @@ if mount -t 9p -o "trans=virtio,version=${bootver},cache=loose" hostshare /mnt/9
           # Per-test timeout (LOG_COMPILER) so a hung script FAILs that test instead of
           # stalling the whole suite under a single outer timeout.
           set +e
-          sudo -u v9fs -H make -C t check \
+          sudo -u v9fs -H stdbuf -oL -eL make -C t check \
             LOG_COMPILER=timeout \
             AM_LOG_FLAGS=300 \
             TESTS="\
@@ -106,6 +106,14 @@ if mount -t 9p -o "trans=virtio,version=${bootver},cache=loose" hostshare /mnt/9
           " 2>&1 | tee "$make_out"
           make_rc="${PIPESTATUS[0]}"
           set -e
+          # If a timed-out test left a live unix 9p mount, drop it so diod
+          # --socktest / diodrun can exit instead of hanging until qemu timeout.
+          awk '/9p/ && /trans=unix/ {print $5}' /proc/self/mountinfo 2>/dev/null \
+            | while read -r mnt; do
+                umount -l "$mnt" 2>/dev/null || true
+              done
+          pkill -x diod 2>/dev/null || true
+          sleep 1
 
           # Prefer automake combined log; synthesize from tee if missing.
           suite="$build/t/test-suite.log"

--- a/scripts/v9fs-mount-9p.c
+++ b/scripts/v9fs-mount-9p.c
@@ -3,6 +3,9 @@
  * util-linux mount(8) post-checks as euid 0 and fails when access=<uid>.
  * This calls mount(2) directly with no post-check.
  *
+ * If options contain access=<uid>, setfsuid to that uid before mount so the
+ * kernel session matches the ACCESS_SINGLE user (mounter may be root via sudo).
+ *
  * Usage: v9fs-mount-9p [-n] -t 9p -o OPTS SOURCE MNT
  *   -n is accepted and ignored (compatibility with sharness mountcmd).
  */
@@ -14,6 +17,10 @@
 #include <string.h>
 #include <unistd.h>
 #include <sys/mount.h>
+#include <sys/types.h>
+
+/* setfsuid(2) is Linux-only; declare if headers omit it. */
+extern int setfsuid(uid_t fsuid);
 
 static void
 usage(const char *prog)
@@ -23,6 +30,25 @@ usage(const char *prog)
 	exit(2);
 }
 
+static uid_t
+parse_access_uid(const char *opts)
+{
+	const char *p = opts;
+
+	while (p && *p) {
+		if (!strncmp(p, "access=", 7)) {
+			p += 7;
+			if (*p >= '0' && *p <= '9')
+				return (uid_t)strtoul(p, NULL, 10);
+			return (uid_t)-1;
+		}
+		p = strchr(p, ',');
+		if (p)
+			p++;
+	}
+	return (uid_t)-1;
+}
+
 int
 main(int argc, char **argv)
 {
@@ -30,6 +56,7 @@ main(int argc, char **argv)
 	const char *source = NULL;
 	const char *target = NULL;
 	unsigned long flags = 0;
+	uid_t access_uid;
 	int i;
 
 	for (i = 1; i < argc; i++) {
@@ -67,9 +94,21 @@ main(int argc, char **argv)
 		usage(argv[0]);
 
 	if (geteuid() != 0) {
-		fprintf(stderr, "%s: must run with CAP_SYS_ADMIN (use sudo)\n",
-			argv[0]);
+		fprintf(stderr, "%s: must run as root (use sudo)\n", argv[0]);
 		return 1;
+	}
+
+	access_uid = parse_access_uid(opts);
+	if (access_uid != (uid_t)-1) {
+		/* Keep CAP_SYS_ADMIN as root euid; match ACCESS_SINGLE for VFS.
+		 * setfsuid returns the previous fsuid (not -1) even on success.
+		 */
+		setfsuid(access_uid);
+		if ((uid_t)setfsuid(access_uid) != access_uid) {
+			fprintf(stderr, "%s: setfsuid(%u) did not stick\n",
+				argv[0], (unsigned)access_uid);
+			return 1;
+		}
 	}
 
 	if (mount(source, target, "9p", flags, opts) < 0) {

--- a/scripts/v9fs-mount-9p.c
+++ b/scripts/v9fs-mount-9p.c
@@ -1,0 +1,73 @@
+/*
+ * Minimal 9p mount helper for diod sharness under ACCESS_SINGLE.
+ * util-linux mount(8) post-checks as euid 0 and fails when access=<uid>.
+ * This calls mount(2) directly with no post-check.
+ *
+ * Usage: v9fs-mount-9p [-n] -t 9p -o OPTS SOURCE MNT
+ *   -n is accepted and ignored (compatibility with sharness mountcmd).
+ */
+
+#define _GNU_SOURCE
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/mount.h>
+
+static void
+usage(const char *prog)
+{
+	fprintf(stderr,
+		"usage: %s [-n] -t 9p -o OPTS SOURCE MNT\n", prog);
+	exit(2);
+}
+
+int
+main(int argc, char **argv)
+{
+	const char *opts = NULL;
+	const char *source = NULL;
+	const char *target = NULL;
+	unsigned long flags = 0;
+	int i;
+
+	for (i = 1; i < argc; i++) {
+		if (!strcmp(argv[i], "-n"))
+			continue;
+		if (!strcmp(argv[i], "-t")) {
+			if (++i >= argc || strcmp(argv[i], "9p") != 0)
+				usage(argv[0]);
+			continue;
+		}
+		if (!strcmp(argv[i], "-o")) {
+			if (++i >= argc)
+				usage(argv[0]);
+			opts = argv[i];
+			continue;
+		}
+		if (!source)
+			source = argv[i];
+		else if (!target)
+			target = argv[i];
+		else
+			usage(argv[0]);
+	}
+
+	if (!opts || !source || !target)
+		usage(argv[0]);
+
+	if (geteuid() != 0) {
+		fprintf(stderr, "%s: must run with CAP_SYS_ADMIN (use sudo)\n",
+			argv[0]);
+		return 1;
+	}
+
+	if (mount(source, target, "9p", flags, opts) < 0) {
+		fprintf(stderr, "%s: mount %s -> %s (%s): %s\n",
+			argv[0], source, target, opts, strerror(errno));
+		return 1;
+	}
+
+	return 0;
+}

--- a/scripts/v9fs-mount-9p.c
+++ b/scripts/v9fs-mount-9p.c
@@ -35,15 +35,24 @@ main(int argc, char **argv)
 	for (i = 1; i < argc; i++) {
 		if (!strcmp(argv[i], "-n"))
 			continue;
-		if (!strcmp(argv[i], "-t")) {
-			if (++i >= argc || strcmp(argv[i], "9p") != 0)
+		if (!strcmp(argv[i], "-t") || !strncmp(argv[i], "-t", 2)) {
+			const char *fstype = argv[i][2] ? argv[i] + 2 : NULL;
+			if (!fstype) {
+				if (++i >= argc)
+					usage(argv[0]);
+				fstype = argv[i];
+			}
+			if (strcmp(fstype, "9p") != 0)
 				usage(argv[0]);
 			continue;
 		}
-		if (!strcmp(argv[i], "-o")) {
-			if (++i >= argc)
-				usage(argv[0]);
-			opts = argv[i];
+		if (!strcmp(argv[i], "-o") || !strncmp(argv[i], "-o", 2)) {
+			opts = argv[i][2] ? argv[i] + 2 : NULL;
+			if (!opts) {
+				if (++i >= argc)
+					usage(argv[0]);
+				opts = argv[i];
+			}
 			continue;
 		}
 		if (!source)

--- a/scripts/v9fs-prepare-diod-regression
+++ b/scripts/v9fs-prepare-diod-regression
@@ -9,7 +9,7 @@ build_link="${DIOD_BUILD:-/workspaces/tmp/diod-build}"
 repo="${DIOD_REPO:-https://github.com/chaos/diod}"
 ref="${DIOD_REF:-master}"
 # Bump when harness patches change so CI does not reuse a stale content-addressed build.
-patch_stamp="${DIOD_PATCH_STAMP:-mount-capsh-v2}"
+patch_stamp="${DIOD_PATCH_STAMP:-mount-capsh-v3}"
 
 export DEBIAN_FRONTEND=noninteractive
 apt-get update -y
@@ -190,7 +190,7 @@ v9fs_access_mount() {
 \tif test \"$(id -u)\" = \"0\"; then
 \t\tmount \"$@\"
 \telse
-\t\tcapsh --caps=cap_sys_admin+ep --keep=1 --inh=1 --user=\"$(id -un)\" -- \\
+\t\t$SUDO capsh --caps=cap_sys_admin+ep --keep=1 --inh=1 --user=\"$(id -un)\" -- \\
 \t\t    -c 'exec mount \"$@\"' _ \"$@\"
 \tfi
 }
@@ -199,13 +199,18 @@ v9fs_access_umount() {
 \tif test \"$(id -u)\" = \"0\"; then
 \t\tumount \"$@\"
 \telse
-\t\tcapsh --caps=cap_sys_admin+ep --keep=1 --inh=1 --user=\"$(id -un)\" -- \\
+\t\t$SUDO capsh --caps=cap_sys_admin+ep --keep=1 --inh=1 --user=\"$(id -un)\" -- \\
 \t\t    -c 'exec umount \"$@\"' _ \"$@\"
 \tfi
 }
 
 """
-if "v9fs_access_mount()" not in h:
+if "v9fs_access_mount()" in h:
+    h = h.replace(
+        "\t\tcapsh --caps=cap_sys_admin+ep",
+        "\t\t$SUDO capsh --caps=cap_sys_admin+ep",
+    )
+else:
     anchor = "# Usage: waitsock sockpath [retries]\nwaitsock() {"
     if anchor not in h:
         raise SystemExit("20-diod.sh: waitsock anchor not found for mount helpers")

--- a/scripts/v9fs-prepare-diod-regression
+++ b/scripts/v9fs-prepare-diod-regression
@@ -9,7 +9,7 @@ build_link="${DIOD_BUILD:-/workspaces/tmp/diod-build}"
 repo="${DIOD_REPO:-https://github.com/chaos/diod}"
 ref="${DIOD_REF:-master}"
 # Bump when harness patches change so CI does not reuse a stale content-addressed build.
-patch_stamp="${DIOD_PATCH_STAMP:-mount-instrument-v1}"
+patch_stamp="${DIOD_PATCH_STAMP:-mount-capsh-v2}"
 
 export DEBIAN_FRONTEND=noninteractive
 apt-get update -y
@@ -95,11 +95,38 @@ if old_under not in text:
     raise SystemExit("t0010: test_under_diod block not found for patch")
 text = text.replace(old_under, new_under, 1)
 
-text = text.replace(
-    'mountopts="trans=unix,uname=$(id -un)"',
-    'mountopts="trans=unix,version=9p2000.L,uname=$(id -un)"',
-    1,
-)
+old_cmds = """umountcmd=\"$SUDO umount -l\"
+mountcmd=\"$SUDO mount -n -t 9p\"
+mountopts=\"trans=unix,uname=$(id -un)\"
+"""
+new_cmds = """if test \"$(id -u)\" = \"0\"; then
+	umountcmd=\"$SUDO umount -l\"
+	mountcmd=\"$SUDO mount -n -t 9p\"
+else
+	# util-linux post-mount check runs as euid 0; ACCESS_SINGLE needs mounter == access uid.
+	umountcmd=\"v9fs_access_umount -l\"
+	mountcmd=\"v9fs_access_mount -n -t 9p\"
+fi
+mountopts=\"trans=unix,version=9p2000.L,uname=$(id -un)\"
+"""
+if old_cmds not in text:
+    # idempotent re-run: mountopts may already be patched
+    old_cmds = """umountcmd=\"$SUDO umount -l\"
+mountcmd=\"$SUDO mount -n -t 9p\"
+mountopts=\"trans=unix,version=9p2000.L,uname=$(id -un)\"
+"""
+    new_cmds = """if test \"$(id -u)\" = \"0\"; then
+	umountcmd=\"$SUDO umount -l\"
+	mountcmd=\"$SUDO mount -n -t 9p\"
+else
+	umountcmd=\"v9fs_access_umount -l\"
+	mountcmd=\"v9fs_access_mount -n -t 9p\"
+fi
+mountopts=\"trans=unix,version=9p2000.L,uname=$(id -un)\"
+"""
+if old_cmds not in text:
+    raise SystemExit("t0010: mountcmd block not found for patch")
+text = text.replace(old_cmds, new_cmds, 1)
 
 old_mount = """test_expect_success 'mount filesystem with access=<uid> on mnt' '
 	$mountcmd -oaname=$exportdir,$mountopts,access=$(id -u) \\
@@ -155,6 +182,35 @@ print(f"patched {t0010}")
 
 helper = src / "t" / "sharness.d" / "20-diod.sh"
 h = helper.read_text()
+
+mount_helpers = """
+# Mount/umount as the test uid with CAP_SYS_ADMIN. sudo mount runs util-linux
+# post-check as euid 0, which fails ACCESS_SINGLE when access=<non-root uid>.
+v9fs_access_mount() {
+\tif test \"$(id -u)\" = \"0\"; then
+\t\tmount \"$@\"
+\telse
+\t\tcapsh --caps=cap_sys_admin+ep --keep=1 --inh=1 --user=\"$(id -un)\" -- \\
+\t\t    -c 'exec mount \"$@\"' _ \"$@\"
+\tfi
+}
+
+v9fs_access_umount() {
+\tif test \"$(id -u)\" = \"0\"; then
+\t\tumount \"$@\"
+\telse
+\t\tcapsh --caps=cap_sys_admin+ep --keep=1 --inh=1 --user=\"$(id -un)\" -- \\
+\t\t    -c 'exec umount \"$@\"' _ \"$@\"
+\tfi
+}
+
+"""
+if "v9fs_access_mount()" not in h:
+    anchor = "# Usage: waitsock sockpath [retries]\nwaitsock() {"
+    if anchor not in h:
+        raise SystemExit("20-diod.sh: waitsock anchor not found for mount helpers")
+    h = h.replace(anchor, mount_helpers + anchor, 1)
+
 # Do not delete diod server logs; CI copies them from the build tree after make check.
 old_cleanup = """\tif test -n "$TEST_UNDER_DIOD_ACTIVE"; then
 \t\ttest "$debug" = "t" || cleanup rm -f "${SHARNESS_TEST_DIRECTORY:-..}/$log_file"
@@ -181,6 +237,8 @@ if grep -rhq 'test_under_diod unixsocket ' "${src}/t" --include='*.t' 2>/dev/nul
 fi
 grep -q 'diod-t0010-mount-debug' "${src}/t/t0010-v9fs-runasuser.t"
 grep -q 'version=9p2000.L' "${src}/t/t0010-v9fs-runasuser.t"
+grep -q 'v9fs_access_mount' "${src}/t/t0010-v9fs-runasuser.t"
+grep -q 'v9fs_access_mount()' "${src}/t/sharness.d/20-diod.sh"
 
 # Autotools bootstrap.
 (cd "${src}" && ./autogen.sh)

--- a/scripts/v9fs-prepare-diod-regression
+++ b/scripts/v9fs-prepare-diod-regression
@@ -172,10 +172,13 @@ helper.write_text(h.replace(old_cleanup, new_cleanup, 1))
 print(f"patched {helper}")
 PY
 
-n_root=$(grep -h -c 'test_under_diod unixsocketroot' "${src}/t/"*.t 2>/dev/null | awk '{s+=$1} END {print s+0}')
-n_unix=$(grep -h -c 'test_under_diod unixsocket ' "${src}/t/"*.t 2>/dev/null | awk '{s+=$1} END {print s+0}')
-echo "diod harness patch: unixsocketroot=${n_root} remaining_unixsocket=${n_unix} stamp=${patch_stamp}"
-test "${n_unix}" = "0"
+n_root=$(grep -rh 'test_under_diod unixsocketroot' "${src}/t" --include='*.t' 2>/dev/null | wc -l | tr -d ' ' || true)
+echo "diod harness patch: unixsocketroot=${n_root} stamp=${patch_stamp}"
+if grep -rhq 'test_under_diod unixsocket ' "${src}/t" --include='*.t' 2>/dev/null; then
+  echo "ERROR: remaining test_under_diod unixsocket references after patch" >&2
+  grep -rn 'test_under_diod unixsocket ' "${src}/t" --include='*.t' >&2 || true
+  exit 1
+fi
 grep -q 'diod-t0010-mount-debug' "${src}/t/t0010-v9fs-runasuser.t"
 grep -q 'version=9p2000.L' "${src}/t/t0010-v9fs-runasuser.t"
 

--- a/scripts/v9fs-prepare-diod-regression
+++ b/scripts/v9fs-prepare-diod-regression
@@ -8,6 +8,8 @@ src="${DIOD_SRC:-/workspaces/tmp/diod-src}"
 build_link="${DIOD_BUILD:-/workspaces/tmp/diod-build}"
 repo="${DIOD_REPO:-https://github.com/chaos/diod}"
 ref="${DIOD_REF:-master}"
+# Bump when harness patches change so CI does not reuse a stale content-addressed build.
+patch_stamp="${DIOD_PATCH_STAMP:-mount-instrument-v1}"
 
 export DEBIAN_FRONTEND=noninteractive
 apt-get update -y
@@ -35,10 +37,11 @@ if ! grep -q 'v9fs-guest' /etc/hosts 2>/dev/null; then
 fi
 cat >/etc/sudoers.d/v9fs-nopasswd <<'EOF'
 Defaults !fqdn
+Defaults !requiretty
 v9fs ALL=(ALL) NOPASSWD:ALL
 EOF
 chmod 440 /etc/sudoers.d/v9fs-nopasswd
-# Validate passwordless sudo before the guest boots.
+# Validate passwordless sudo before the guest boots (no tty, like diodrun setsid).
 sudo -u v9fs sudo -n true
 
 # Clone/update source.
@@ -49,17 +52,140 @@ fi
 git -C "${src}" fetch --depth 1 origin "${ref}" || true
 git -C "${src}" checkout -q "${ref}" || true
 
+# Reset patched files so re-prepare is idempotent.
+git -C "${src}" checkout -q -- \
+  t/t0010-v9fs-runasuser.t \
+  t/sharness.d/20-diod.sh \
+  || true
+
 # Start diod as root then drop to --runas (production path). Non-root
 # `unixsocket` left us with flaky mounts (ECONNREFUSED / cascading FAILs)
 # even though waitsock passed; `unixsocketroot` matches diod's own root→runas flow.
 find "${src}/t" -type f -name 't*.t' -print0 \
   | xargs -0 sed -i 's/test_under_diod unixsocket /test_under_diod unixsocketroot /g'
 
+# Harness patches: keep diod logs, pre-create export, instrument first mount,
+# and pin dialect. Do NOT connect-probe the unix socket before the long-lived
+# mount — diod --socktest exits once the first connection drops to zero.
+python3 - <<'PY' "${src}"
+import pathlib, sys
+src = pathlib.Path(sys.argv[1])
+
+t0010 = src / "t" / "t0010-v9fs-runasuser.t"
+text = t0010.read_text()
+old_under = """exportdir=$SHARNESS_TRASH_DIRECTORY/exp
+test_under_diod unixsocketroot \\
+    --config-file=/dev/null \\
+    --debug=0x1 \\
+    --runas=$(id -u) \\
+    --no-auth \\
+    --export=$exportdir
+"""
+new_under = """exportdir=$SHARNESS_TRASH_DIRECTORY/exp
+# Export must exist before diod attach; create early (idempotent across re-exec).
+mkdir -p "$exportdir"
+test_under_diod unixsocketroot \\
+    --config-file=/dev/null \\
+    --debug=0x1 \\
+    --runas=$(id -u) \\
+    --no-auth \\
+    --export=$exportdir
+"""
+if old_under not in text:
+    raise SystemExit("t0010: test_under_diod block not found for patch")
+text = text.replace(old_under, new_under, 1)
+
+text = text.replace(
+    'mountopts="trans=unix,uname=$(id -un)"',
+    'mountopts="trans=unix,version=9p2000.L,uname=$(id -un)"',
+    1,
+)
+
+old_mount = """test_expect_success 'mount filesystem with access=<uid> on mnt' '
+	$mountcmd -oaname=$exportdir,$mountopts,access=$(id -u) \\
+	    $DIOD_SOCKET mnt
+'
+"""
+new_mount = """test_expect_success 'mount filesystem with access=<uid> on mnt' '
+	dbg=/home/v9fs-test/test/logs/diod-t0010-mount-debug.txt &&
+	mkdir -p /home/v9fs-test/test/logs &&
+	set +e &&
+	{
+	  echo "=== mount debug ==="
+	  id
+	  getent passwd "$(id -un)"
+	  echo "exportdir=$exportdir"
+	  echo "DIOD_SOCKET=$DIOD_SOCKET"
+	  echo "mountopts=$mountopts"
+	  echo "access=$(id -u) uname=$(id -un)"
+	  ls -ld "$exportdir" "$DIOD_SOCKET" "$(dirname "$DIOD_SOCKET")"
+	  ls -l "$DIOD_SOCKET"
+	  echo "--- diod log (pre) ---"
+	  cat "${SHARNESS_TEST_DIRECTORY:-..}/$SHARNESS_TEST_NAME.diod.log"
+	  echo "--- dmesg (pre) ---"
+	  dmesg | tail -n 40
+	  echo "--- mount command ---"
+	  echo "$mountcmd -oaname=$exportdir,$mountopts,access=$(id -u) $DIOD_SOCKET mnt"
+	  $mountcmd -oaname=$exportdir,$mountopts,access=$(id -u) \\
+	      $DIOD_SOCKET mnt >mount.stdout 2>mount.stderr
+	  echo $? >mount.rc
+	  echo "mount_rc=$(cat mount.rc)"
+	  echo "--- mount stdout ---"; cat mount.stdout
+	  echo "--- mount stderr ---"; cat mount.stderr
+	  echo "--- diod log (post) ---"
+	  cat "${SHARNESS_TEST_DIRECTORY:-..}/$SHARNESS_TEST_NAME.diod.log"
+	  echo "--- dmesg (post) ---"
+	  dmesg | tail -n 80
+	  echo "--- mount | grep 9p ---"
+	  mount | grep 9p
+	} >"$dbg" 2>&1
+	cp -f "$dbg" "${SHARNESS_TEST_DIRECTORY:-..}/diod-t0010-mount-debug.txt"
+	cp -f "${SHARNESS_TEST_DIRECTORY:-..}/$SHARNESS_TEST_NAME.diod.log" \\
+	  /home/v9fs-test/test/logs/t0010-v9fs-runasuser.t.diod.log
+	echo "diod-t0010: mount debug at $dbg rc=$(cat mount.rc 2>/dev/null)"
+	set -e &&
+	test "$(cat mount.rc)" = "0"
+'
+"""
+if old_mount not in text:
+    raise SystemExit("t0010: mount test block not found for patch")
+text = text.replace(old_mount, new_mount, 1)
+t0010.write_text(text)
+print(f"patched {t0010}")
+
+helper = src / "t" / "sharness.d" / "20-diod.sh"
+h = helper.read_text()
+# Do not delete diod server logs; CI copies them from the build tree after make check.
+old_cleanup = """\tif test -n "$TEST_UNDER_DIOD_ACTIVE"; then
+\t\ttest "$debug" = "t" || cleanup rm -f "${SHARNESS_TEST_DIRECTORY:-..}/$log_file"
+\t\treturn
+\tfi
+"""
+new_cleanup = """\tif test -n "$TEST_UNDER_DIOD_ACTIVE"; then
+\t\t# Keep $log_file for harness triage (was removed unless --debug).
+\t\treturn
+\tfi
+"""
+if old_cleanup not in h:
+    raise SystemExit("20-diod.sh: cleanup block not found for patch")
+helper.write_text(h.replace(old_cleanup, new_cleanup, 1))
+print(f"patched {helper}")
+PY
+
+n_root=$(grep -c 'test_under_diod unixsocketroot' "${src}/t/"*.t || true)
+n_unix=$(grep -c 'test_under_diod unixsocket ' "${src}/t/"*.t || true)
+echo "diod harness patch: unixsocketroot=${n_root} remaining_unixsocket=${n_unix} stamp=${patch_stamp}"
+test "${n_unix}" = "0"
+grep -q 'diod-t0010-mount-debug' "${src}/t/t0010-v9fs-runasuser.t"
+grep -q 'version=9p2000.L' "${src}/t/t0010-v9fs-runasuser.t"
+
 # Autotools bootstrap.
 (cd "${src}" && ./autogen.sh)
 
 # Build in a content-addressed directory (avoids cleanup issues with mixed uid mappings).
-build_real="/workspaces/tmp/diod-build-$(git -C "${src}" rev-parse --short HEAD)"
+build_real="/workspaces/tmp/diod-build-$(git -C "${src}" rev-parse --short HEAD)-${patch_stamp}"
+# Drop any previous stamp build for this tip so configure/make see fresh patched sources.
+rm -rf "${build_real}"
 mkdir -p "${build_real}"
 
 (cd "${build_real}" && "${src}/configure")
@@ -67,6 +193,8 @@ mkdir -p "${build_real}"
 
 # Record the build directory for the guest (symlinks can be awkward across 9p+bind mounts).
 echo "${build_real}" > /workspaces/tmp/diod-build.LATEST
+# Convenience link for humans/scripts.
+ln -sfn "${build_real}" "${build_link}" 2>/dev/null || true
 
 # The guest writes test logs into the build tree; ensure it's writable over 9p
 # regardless of uid mapping.
@@ -74,4 +202,3 @@ chmod -R a+rwX "${src}" "${build_real}" || true
 
 echo "Prepared diod build at ${build_real}"
 ls -la "${build_real}/t" | head -n 50 || true
-

--- a/scripts/v9fs-prepare-diod-regression
+++ b/scripts/v9fs-prepare-diod-regression
@@ -9,7 +9,7 @@ build_link="${DIOD_BUILD:-/workspaces/tmp/diod-build}"
 repo="${DIOD_REPO:-https://github.com/chaos/diod}"
 ref="${DIOD_REF:-master}"
 # Bump when harness patches change so CI does not reuse a stale content-addressed build.
-patch_stamp="${DIOD_PATCH_STAMP:-mount-helper-v4}"
+patch_stamp="${DIOD_PATCH_STAMP:-mount-helper-v5}"
 
 export DEBIAN_FRONTEND=noninteractive
 apt-get update -y

--- a/scripts/v9fs-prepare-diod-regression
+++ b/scripts/v9fs-prepare-diod-regression
@@ -9,7 +9,7 @@ build_link="${DIOD_BUILD:-/workspaces/tmp/diod-build}"
 repo="${DIOD_REPO:-https://github.com/chaos/diod}"
 ref="${DIOD_REF:-master}"
 # Bump when harness patches change so CI does not reuse a stale content-addressed build.
-patch_stamp="${DIOD_PATCH_STAMP:-mount-helper-v5}"
+patch_stamp="${DIOD_PATCH_STAMP:-mount-helper-v6}"
 
 export DEBIAN_FRONTEND=noninteractive
 apt-get update -y
@@ -43,6 +43,8 @@ EOF
 chmod 440 /etc/sudoers.d/v9fs-nopasswd
 # Validate passwordless sudo before the guest boots (no tty, like diodrun setsid).
 sudo -u v9fs sudo -n true
+# Avoid util-linux "Too many levels of symbolic links" on broken /etc/mtab.
+ln -sfn /proc/self/mounts /etc/mtab
 
 # Clone/update source.
 if [ ! -d "${src}/.git" ]; then
@@ -140,38 +142,26 @@ new_mount = """test_expect_success 'mount filesystem with access=<uid> on mnt' '
 	{
 	  echo "=== mount debug ==="
 	  id
-	  getent passwd "$(id -un)"
-	  echo "exportdir=$exportdir"
-	  echo "DIOD_SOCKET=$DIOD_SOCKET"
-	  echo "mountopts=$mountopts"
-	  echo "access=$(id -u) uname=$(id -un)"
-	  ls -ld "$exportdir" "$DIOD_SOCKET" "$(dirname "$DIOD_SOCKET")"
+	  echo "exportdir=$exportdir DIOD_SOCKET=$DIOD_SOCKET"
+	  echo "mountcmd=$mountcmd"
+	  echo "opts=aname=$exportdir,$mountopts,access=$(id -u)"
 	  ls -l "$DIOD_SOCKET"
-	  echo "--- diod log (pre) ---"
 	  cat "${SHARNESS_TEST_DIRECTORY:-..}/$SHARNESS_TEST_NAME.diod.log"
-	  echo "--- dmesg (pre) ---"
-	  dmesg | tail -n 40
-	  echo "--- mount command ---"
-	  echo "$mountcmd -oaname=$exportdir,$mountopts,access=$(id -u) $DIOD_SOCKET mnt"
 	  $mountcmd -oaname=$exportdir,$mountopts,access=$(id -u) \\
 	      $DIOD_SOCKET mnt >mount.stdout 2>mount.stderr
 	  echo $? >mount.rc
 	  echo "mount_rc=$(cat mount.rc)"
-	  echo "--- mount stdout ---"; cat mount.stdout
-	  echo "--- mount stderr ---"; cat mount.stderr
-	  echo "--- diod log (post) ---"
+	  cat mount.stdout; cat mount.stderr
 	  cat "${SHARNESS_TEST_DIRECTORY:-..}/$SHARNESS_TEST_NAME.diod.log"
-	  echo "--- dmesg (post) ---"
-	  dmesg | tail -n 80
-	  echo "--- mount | grep 9p ---"
-	  mount | grep 9p
+	  grep 9p /proc/self/mountinfo
 	} >"$dbg" 2>&1
 	cp -f "$dbg" "${SHARNESS_TEST_DIRECTORY:-..}/diod-t0010-mount-debug.txt"
 	cp -f "${SHARNESS_TEST_DIRECTORY:-..}/$SHARNESS_TEST_NAME.diod.log" \\
 	  /home/v9fs-test/test/logs/t0010-v9fs-runasuser.t.diod.log
 	echo "diod-t0010: mount debug at $dbg rc=$(cat mount.rc 2>/dev/null)"
 	set -e &&
-	test "$(cat mount.rc)" = "0"
+	test "$(cat mount.rc)" = "0" &&
+	cleanup $umountcmd mnt
 '
 """
 if old_mount not in text:

--- a/scripts/v9fs-prepare-diod-regression
+++ b/scripts/v9fs-prepare-diod-regression
@@ -172,8 +172,8 @@ helper.write_text(h.replace(old_cleanup, new_cleanup, 1))
 print(f"patched {helper}")
 PY
 
-n_root=$(grep -c 'test_under_diod unixsocketroot' "${src}/t/"*.t || true)
-n_unix=$(grep -c 'test_under_diod unixsocket ' "${src}/t/"*.t || true)
+n_root=$(grep -h -c 'test_under_diod unixsocketroot' "${src}/t/"*.t 2>/dev/null | awk '{s+=$1} END {print s+0}')
+n_unix=$(grep -h -c 'test_under_diod unixsocket ' "${src}/t/"*.t 2>/dev/null | awk '{s+=$1} END {print s+0}')
 echo "diod harness patch: unixsocketroot=${n_root} remaining_unixsocket=${n_unix} stamp=${patch_stamp}"
 test "${n_unix}" = "0"
 grep -q 'diod-t0010-mount-debug' "${src}/t/t0010-v9fs-runasuser.t"

--- a/scripts/v9fs-prepare-diod-regression
+++ b/scripts/v9fs-prepare-diod-regression
@@ -9,7 +9,7 @@ build_link="${DIOD_BUILD:-/workspaces/tmp/diod-build}"
 repo="${DIOD_REPO:-https://github.com/chaos/diod}"
 ref="${DIOD_REF:-master}"
 # Bump when harness patches change so CI does not reuse a stale content-addressed build.
-patch_stamp="${DIOD_PATCH_STAMP:-mount-capsh-v3}"
+patch_stamp="${DIOD_PATCH_STAMP:-mount-helper-v4}"
 
 export DEBIAN_FRONTEND=noninteractive
 apt-get update -y
@@ -184,14 +184,20 @@ helper = src / "t" / "sharness.d" / "20-diod.sh"
 h = helper.read_text()
 
 mount_helpers = """
-# Mount/umount as the test uid with CAP_SYS_ADMIN. sudo mount runs util-linux
-# post-check as euid 0, which fails ACCESS_SINGLE when access=<non-root uid>.
+V9FS_MOUNT_9P=/workspaces/tmp/v9fs-mount-9p
+
+# Minimal mount(2) helper avoids util-linux post-check as root under ACCESS_SINGLE.
 v9fs_access_mount() {
-\tif test \"$(id -u)\" = \"0\"; then
+\tif test -x \"$V9FS_MOUNT_9P\"; then
+\t\tif test \"$(id -u)\" = \"0\"; then
+\t\t\t\"$V9FS_MOUNT_9P\" \"$@\"
+\t\telse
+\t\t\t$SUDO \"$V9FS_MOUNT_9P\" \"$@\"
+\t\tfi
+\telif test \"$(id -u)\" = \"0\"; then
 \t\tmount \"$@\"
 \telse
-\t\t$SUDO capsh --caps=cap_sys_admin+ep --keep=1 --inh=1 --user=\"$(id -un)\" -- \\
-\t\t    -c 'exec mount \"$@\"' _ \"$@\"
+\t\t$SUDO mount \"$@\"
 \tfi
 }
 
@@ -199,16 +205,19 @@ v9fs_access_umount() {
 \tif test \"$(id -u)\" = \"0\"; then
 \t\tumount \"$@\"
 \telse
-\t\t$SUDO capsh --caps=cap_sys_admin+ep --keep=1 --inh=1 --user=\"$(id -un)\" -- \\
-\t\t    -c 'exec umount \"$@\"' _ \"$@\"
+\t\t$SUDO umount \"$@\"
 \tfi
 }
 
 """
 if "v9fs_access_mount()" in h:
-    h = h.replace(
-        "\t\tcapsh --caps=cap_sys_admin+ep",
-        "\t\t$SUDO capsh --caps=cap_sys_admin+ep",
+    import re
+    h = re.sub(
+        r"\nV9FS_MOUNT_9P=.*?\nv9fs_access_umount\(\) \{.*?\n\}\n\n",
+        "\n" + mount_helpers,
+        h,
+        count=1,
+        flags=re.S,
     )
 else:
     anchor = "# Usage: waitsock sockpath [retries]\nwaitsock() {"
@@ -243,7 +252,11 @@ fi
 grep -q 'diod-t0010-mount-debug' "${src}/t/t0010-v9fs-runasuser.t"
 grep -q 'version=9p2000.L' "${src}/t/t0010-v9fs-runasuser.t"
 grep -q 'v9fs_access_mount' "${src}/t/t0010-v9fs-runasuser.t"
-grep -q 'v9fs_access_mount()' "${src}/t/sharness.d/20-diod.sh"
+grep -q 'V9FS_MOUNT_9P' "${src}/t/sharness.d/20-diod.sh"
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+gcc -O2 -o /workspaces/tmp/v9fs-mount-9p "${script_dir}/v9fs-mount-9p.c"
+chmod 755 /workspaces/tmp/v9fs-mount-9p
 
 # Autotools bootstrap.
 (cd "${src}" && ./autogen.sh)


### PR DESCRIPTION
## Summary
- Instrument `t0010` first `access=<uid>` mount to capture stderr, dmesg, and diod server log into CI artifacts
- Pre-create export dir before `test_under_diod`; pin `version=9p2000.L`; `Defaults !requiretty`
- Force a fresh content-addressed build stamp so prepare patches are not stale

## Test plan
- [ ] Dispatch harness on this branch (`kernel-latest`)
- [ ] Confirm `diod-t0010-mount-debug.txt` (and `.diod.log`) appear in diod-regression artifacts
- [ ] Use captured error to land the real mount fix (follow-up commit or PR)

Made with [Cursor](https://cursor.com)